### PR TITLE
copy: add --keep-ownership flag

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -21,6 +21,7 @@ type addCopyResults struct {
 	addHistory       bool
 	chmod            string
 	chown            string
+	keepOwnership    bool
 	quiet            bool
 	ignoreFile       string
 	contextdir       string
@@ -66,6 +67,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	}
 	flags.StringVar(&opts.chown, "chown", "", "set the user and group ownership of the destination content")
 	flags.StringVar(&opts.chmod, "chmod", "", "set the access permissions of the destination content")
+	flags.BoolVar(&opts.keepOwnership, "keep-ownership", false, "preserve user and group ownership of source content (only for local files)")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing registries when pulling images")
 	if err := flags.MarkHidden("creds"); err != nil {
 		panic(fmt.Sprintf("error marking creds as hidden: %v", err))
@@ -222,10 +224,11 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	builder.ContentDigester.Restart()
 
 	options := buildah.AddAndCopyOptions{
-		Chmod:            iopts.chmod,
-		Chown:            iopts.chown,
-		ContextDir:       contextdir,
-		IDMappingOptions: idMappingOptions,
+		Chmod:             iopts.chmod,
+		Chown:             iopts.chown,
+		ContextDir:        contextdir,
+		IDMappingOptions:  idMappingOptions,
+		PreserveOwnership: iopts.keepOwnership,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string


### PR DESCRIPTION
This exposes the already existing KeepOwnership flag to the
copy and add CLI commands.

Signed-off-by: Ruben Jenster <r.jenster@drachenfels.de>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

